### PR TITLE
Feature/usecase load

### DIFF
--- a/Lucent/Domain/UseCase/LoadFocusSessionsUseCase.swift
+++ b/Lucent/Domain/UseCase/LoadFocusSessionsUseCase.swift
@@ -1,0 +1,12 @@
+//
+//  LoadFocusSessionsUseCase.swift
+//  Lucent
+//
+//  Created by 김동현 on 4/15/25.
+//
+
+import Foundation
+
+protocol LoadFocusSessionsUseCase {
+    func excute() async throws -> [FocusSession]
+}

--- a/Lucent/Domain/UseCase/LoadFocusSessionsUseCaseImpl.swift
+++ b/Lucent/Domain/UseCase/LoadFocusSessionsUseCaseImpl.swift
@@ -1,0 +1,20 @@
+//
+//  LoadFocusSessionsUseCaseImpl.swift
+//  Lucent
+//
+//  Created by 김동현 on 4/15/25.
+//
+
+import Foundation
+
+final class LoadFocusSessionsUseCaseImpl: LoadFocusSessionsUseCase {
+    private let repository: FocusSessionRepository
+
+    init(repository: FocusSessionRepository) {
+        self.repository = repository
+    }
+
+    func excute() async throws -> [FocusSession] {
+        return try await repository.loadAll()
+    }
+}

--- a/Lucent/Presentation/View/FocusHistoryView.swift
+++ b/Lucent/Presentation/View/FocusHistoryView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct FocusHistoryView: View {
     @StateObject private var viewModel: FocusHistoryViewModel
 
-    init(repository: FocusSessionRepository) {
-        _viewModel = StateObject(wrappedValue: FocusHistoryViewModel(repository: repository))
+    init(viewModel: FocusHistoryViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {
@@ -47,6 +47,7 @@ struct FocusHistoryView: View {
 
 #Preview {
     let repository = LocalFocusSessionRepository()
-    return FocusHistoryView(repository: repository)
+    let useCase = LoadFocusSessionsUseCaseImpl(repository: repository)
+    let viewModel = FocusHistoryViewModel(loadUseCase: useCase)
+    FocusHistoryView(viewModel: viewModel)
 }
-

--- a/Lucent/Presentation/View/LucentStarFieldView.swift
+++ b/Lucent/Presentation/View/LucentStarFieldView.swift
@@ -58,6 +58,7 @@ struct LucentStarFieldView: View {
 
 #Preview {
     let repository = LocalFocusSessionRepository()
-    let vm = LucentStarFieldViewModel(repository: repository)
-    return LucentStarFieldView(viewModel: vm)
+    let loadUseCase = LoadFocusSessionsUseCaseImpl(repository: repository)
+    let vm = LucentStarFieldViewModel(loadUseCase: loadUseCase)
+    LucentStarFieldView(viewModel: vm)
 }

--- a/Lucent/Presentation/View/Tab/FocusHistoryTab.swift
+++ b/Lucent/Presentation/View/Tab/FocusHistoryTab.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct FocusHistoryTab: View {
     var body: some View {
         let repository = LocalFocusSessionRepository()
-        FocusHistoryView(repository: repository)
+        let useCase = LoadFocusSessionsUseCaseImpl(repository: repository)
+        let viewModel = FocusHistoryViewModel(loadUseCase: useCase)
+        FocusHistoryView(viewModel: viewModel)
     }
 }
 

--- a/Lucent/Presentation/View/Tab/StarFieldTab.swift
+++ b/Lucent/Presentation/View/Tab/StarFieldTab.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct StarFieldTab: View {
     var body: some View {
         let repository = LocalFocusSessionRepository()
-        let viewModel = LucentStarFieldViewModel(repository: repository)
+        let useCase = LoadFocusSessionsUseCaseImpl(repository: repository)
+        let viewModel = LucentStarFieldViewModel(loadUseCase: useCase)
         LucentStarFieldView(viewModel: viewModel)
     }
 }

--- a/Lucent/Presentation/ViewModel/FocusHistoryViewModel.swift
+++ b/Lucent/Presentation/ViewModel/FocusHistoryViewModel.swift
@@ -11,16 +11,16 @@ import Combine
 final class FocusHistoryViewModel: ObservableObject {
     @Published private(set) var sessions: [FocusSession] = []
 
-    private let repository: FocusSessionRepository
+    private let loadUseCase: LoadFocusSessionsUseCase
 
-    init(repository: FocusSessionRepository) {
-        self.repository = repository
+    init(loadUseCase: LoadFocusSessionsUseCase) {
+        self.loadUseCase = loadUseCase
     }
 
     func loadSessions() {
         Task {
             do {
-                let loaded = try await repository.loadAll()
+                let loaded = try await loadUseCase.excute()
                 DispatchQueue.main.async {
                     self.sessions = loaded.sorted(by: { $0.startTime > $1.startTime })
                 }
@@ -29,4 +29,5 @@ final class FocusHistoryViewModel: ObservableObject {
             }
         }
     }
+
 }

--- a/Lucent/Presentation/ViewModel/LucentStarFieldViewModel.swift
+++ b/Lucent/Presentation/ViewModel/LucentStarFieldViewModel.swift
@@ -11,35 +11,34 @@ import Combine
 
 final class LucentStarFieldViewModel: ObservableObject {
     @Published private(set) var stars: [LucentStar] = []
+    private let loadUseCase: LoadFocusSessionsUseCase
 
-        private let repository: FocusSessionRepository
+    init(loadUseCase: LoadFocusSessionsUseCase) {
+        self.loadUseCase = loadUseCase
+    }
 
-        init(repository: FocusSessionRepository) {
-            self.repository = repository
-        }
+    func loadStars(in size: CGSize) {
+        Task {
+            do {
+                let sessions = try await loadUseCase.excute()
 
-        func loadStars(in size: CGSize) {
-            Task {
-                do {
-                    let sessions = try await repository.loadAll()
-
-                    let mapped = sessions.map { session in
-                        LucentStar(
-                            emotion: session.mood ?? .calm,
-                            position: CGPoint(
-                                x: CGFloat.random(in: 0...size.width),
-                                y: CGFloat.random(in: 0...size.height)
-                            ),
-                            size: CGFloat.random(in: 10...22)
-                        )
-                    }
-
-                    DispatchQueue.main.async {
-                        self.stars = mapped
-                    }
-                } catch {
-                    print("LucentStar 로딩 실패: \(error)")
+                let mapped = sessions.map { session in
+                    LucentStar(
+                        emotion: session.mood ?? .calm,
+                        position: CGPoint(
+                            x: CGFloat.random(in: 0...size.width),
+                            y: CGFloat.random(in: 0...size.height)
+                        ),
+                        size: CGFloat.random(in: 10...22)
+                    )
                 }
+
+                DispatchQueue.main.async {
+                    self.stars = mapped
+                }
+            } catch {
+                print("LucentStar 로딩 실패: \(error)")
             }
         }
+    }
 }


### PR DESCRIPTION
## 주요 변경 사항
- FocusSession 목록 불러오기 책임을 ViewModel에서 UseCase로 분리
- LoadFocusSessionsUseCase 및 LoadFocusSessionsUseCaseImpl 생성
- FocusHistoryViewModel -> UseCase 기반으로 리팩토링
- LucentStarFieldViewModel도 동일한 구조 적용
- View/ViewModel/UseCase 간 의존성 방향을 명확하게 분리 (DIP 원칙 적용)