### PR TITLE
refactor: LoadFocusSessionsUseCase를 Combine 기반 executePublisher() 메서드 추가

### DIFF
--- a/Lucent/Domain/UseCase/LoadFocusSessionsUseCase.swift
+++ b/Lucent/Domain/UseCase/LoadFocusSessionsUseCase.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+import Combine
 
 protocol LoadFocusSessionsUseCase {
     func execute() async throws -> [FocusSession]
+    func excutePublisher() -> AnyPublisher<[FocusSession], Error>
 }

--- a/Lucent/Domain/UseCase/LoadFocusSessionsUseCaseImpl.swift
+++ b/Lucent/Domain/UseCase/LoadFocusSessionsUseCaseImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 final class LoadFocusSessionsUseCaseImpl: LoadFocusSessionsUseCase {
     private let repository: FocusSessionRepository
@@ -16,5 +17,19 @@ final class LoadFocusSessionsUseCaseImpl: LoadFocusSessionsUseCase {
 
     func execute() async throws -> [FocusSession] {
         return try await repository.loadAll()
+    }
+
+    func excutePublisher() -> AnyPublisher<[FocusSession], any Error> {
+        Future { promise in
+            Task {
+                do {
+                    let result = try await self.repository.loadAll()
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
## 변경 사항
- 기존 async throws 기반 LoadFocusSessionsUseCase에 executePublisher() 추가
- Future + Task를 통해 Swift Concurrency 흐름을 Combine 스트림으로 변환
- ViewModel의 스트림 기반 데이터 흐름을 준비하기 위한 사전 작업