### PR TITLE
refactor: FocusHistoryViewModel loadSessions를 Combine 흐름으로 개선

### DIFF
--- a/Lucent/Domain/UseCase/LoadFocusSessionsUseCase.swift
+++ b/Lucent/Domain/UseCase/LoadFocusSessionsUseCase.swift
@@ -10,5 +10,5 @@ import Combine
 
 protocol LoadFocusSessionsUseCase {
     func execute() async throws -> [FocusSession]
-    func excutePublisher() -> AnyPublisher<[FocusSession], Error>
+    func executePublisher() -> AnyPublisher<[FocusSession], Error>
 }

--- a/Lucent/Domain/UseCase/LoadFocusSessionsUseCaseImpl.swift
+++ b/Lucent/Domain/UseCase/LoadFocusSessionsUseCaseImpl.swift
@@ -19,7 +19,7 @@ final class LoadFocusSessionsUseCaseImpl: LoadFocusSessionsUseCase {
         return try await repository.loadAll()
     }
 
-    func excutePublisher() -> AnyPublisher<[FocusSession], any Error> {
+    func executePublisher() -> AnyPublisher<[FocusSession], any Error> {
         Future { promise in
             Task {
                 do {

--- a/Lucent/Presentation/ViewModel/FocusHistoryViewModel.swift
+++ b/Lucent/Presentation/ViewModel/FocusHistoryViewModel.swift
@@ -13,6 +13,7 @@ final class FocusHistoryViewModel: ObservableObject {
 
     private let loadUseCase: LoadFocusSessionsUseCase
     private let deleteUseCase: DeleteFocusSessionUseCase
+    private var cancellables = Set<AnyCancellable>()
 
     init(loadUseCase: LoadFocusSessionsUseCase, deleteUseCase: DeleteFocusSessionUseCase) {
         self.loadUseCase = loadUseCase
@@ -20,16 +21,17 @@ final class FocusHistoryViewModel: ObservableObject {
     }
 
     func loadSessions() {
-        Task {
-            do {
-                let loaded = try await loadUseCase.execute()
-                DispatchQueue.main.async {
-                    self.sessions = loaded.sorted(by: { $0.startTime > $1.startTime })
+        loadUseCase.executePublisher()
+            .map { $0.sorted { $0.startTime > $1.startTime } }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                if case let .failure(error) = completion {
+                    print("세션 불러오기 실패: \(error)")
                 }
-            } catch {
-                print("세션 불러오기 실패: \(error)")
-            }
-        }
+            }, receiveValue: { [weak self] loadedSessions in
+                self?.sessions = loadedSessions
+            })
+            .store(in: &cancellables)
     }
 
     func deleteSession(_ session: FocusSession) {


### PR DESCRIPTION
## 변경 내용
- 기존 FocusHistoryViewModel의 세션 로딩(loadSessions)을 Combine 기반 Publisher 스트림으로 리팩터링했습니다.
- Combine을 통해 ViewModel 내부 상태 변화가 보다 선언적이고, 테스트 가능하게 개선되었습니다.