### PR TITLE
refactor: Save/Delete UseCase에 Combine Publisher 인터페이스 추가

### DIFF
--- a/Lucent/Domain/UseCase/DeleteFocusSessionUseCase.swift
+++ b/Lucent/Domain/UseCase/DeleteFocusSessionUseCase.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+import Combine
 
 protocol DeleteFocusSessionUseCase {
     func execute(session: FocusSession) async throws
+    func executePublisher(session: FocusSession) -> AnyPublisher<Void, Error>
 }

--- a/Lucent/Domain/UseCase/DeleteFocusSessionsUseCaseImpl.swift
+++ b/Lucent/Domain/UseCase/DeleteFocusSessionsUseCaseImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 final class DeleteFocusSessionsUseCaseImpl: DeleteFocusSessionUseCase {
     private let repository: FocusSessionRepository
@@ -17,4 +18,19 @@ final class DeleteFocusSessionsUseCaseImpl: DeleteFocusSessionUseCase {
     func execute(session: FocusSession) async throws {
         try await repository.delete(session: session)
     }
+
+    func executePublisher(session: FocusSession) -> AnyPublisher<Void, Error> {
+        Future { promise in
+            Task {
+                do {
+                    try await self.repository.delete(session: session)
+                    promise(.success(()))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+
 }

--- a/Lucent/Domain/UseCase/SaveFocusSessionUseCase.swift
+++ b/Lucent/Domain/UseCase/SaveFocusSessionUseCase.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+import Combine
 
 protocol SaveFocusSessionUseCase {
     func execute(session: FocusSession) async throws// 비동기 저장 가능성 대비, ex: 파일, 클라우드 등
+    func executePublisher(session: FocusSession) -> AnyPublisher<Void, Error>
 }

--- a/Lucent/Domain/UseCase/SaveFocusSessionUseCaseImpl.swift
+++ b/Lucent/Domain/UseCase/SaveFocusSessionUseCaseImpl.swift
@@ -6,15 +6,30 @@
 //
 
 import Foundation
+import Combine
 
 final class SaveFocusSessionUseCaseImpl: SaveFocusSessionUseCase {
     private let repository: FocusSessionRepository
-
+    
     init(repository: FocusSessionRepository) {
         self.repository = repository
     }
-
+    
     func execute(session: FocusSession) async throws {
         try await repository.save(session: session)
+    }
+    
+    func executePublisher(session: FocusSession) -> AnyPublisher<Void, Error> {
+        Future { promise in
+            Task {
+                do {
+                    try await self.repository.save(session: session)
+                    promise(.success(()))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
## 변경 내용
- SaveFocusSessionUseCase, DeleteFocusSessionUseCase에 executePublisher() 메소드 추가
- Swift Concurrency 기반 비동기 흐름을 Combine 스트림으로 변환하여 확장성 확보